### PR TITLE
 Allow authentication interface to extend session context 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,6 @@ charset = utf-8
 
 [*.go]
 indent_style = tab
-indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -4,6 +4,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 
 	"github.com/TheThingsIndustries/mystique/pkg/topic"
@@ -11,8 +12,8 @@ import (
 
 // Interface for MQTT authentication
 type Interface interface {
-	// Connect or return error code
-	Connect(info *Info) error
+	// Connect, extend context or return error code
+	Connect(ctx context.Context, info *Info) (context.Context, error)
 
 	// Subscribe allows the auth plugin to replace wildcards or to lower the QoS of a subscription.
 	// For example, a client requesting a subscription to "#" may be rewritten to "foo" if they are only allowed to subscribe to that topic.

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -3,6 +3,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -14,11 +15,11 @@ type alwaysAuth struct {
 	ok bool
 }
 
-func (a alwaysAuth) Connect(info *Info) (err error) {
+func (a alwaysAuth) Connect(ctx context.Context, info *Info) (context.Context, error) {
 	if !a.ok {
-		err = errors.New("computer says no")
+		return nil, errors.New("computer says no")
 	}
-	return
+	return ctx, nil
 }
 func (a alwaysAuth) Subscribe(info *Info, requestedTopic string, requestedQoS byte) (acceptedTopic string, acceptedQoS byte, err error) {
 	if !a.ok {

--- a/pkg/auth/ttnauth/ttnauth_test.go
+++ b/pkg/auth/ttnauth/ttnauth_test.go
@@ -3,6 +3,7 @@
 package ttnauth
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -50,7 +51,8 @@ func TestTTNAuth(t *testing.T) {
 	s.AuthenticateApplications()
 	s.AddSuperUser("root", []byte("rootpass"), Access{Root: true})
 
-	a.So(s.Connect(&auth.Info{}), should.NotBeNil)
+	_, err := s.Connect(context.Background(), &auth.Info{})
+	a.So(err, should.NotBeNil)
 
 	empty := &auth.Info{
 		Interface: &TTNAuth{},
@@ -67,7 +69,8 @@ func TestTTNAuth(t *testing.T) {
 		Username: "root",
 		Password: []byte("rootpass"),
 	}
-	a.So(s.Connect(root), should.BeNil)
+	_, err = s.Connect(context.Background(), root)
+	a.So(err, should.BeNil)
 
 	a.So(root.CanRead("any"), should.BeTrue)
 	a.So(root.CanWrite("any"), should.BeTrue)
@@ -78,23 +81,27 @@ func TestTTNAuth(t *testing.T) {
 		Username: "test",
 		Password: []byte("test.incorrect"),
 	}
-	a.So(s.Connect(incorrect), should.NotBeNil)
+	_, err = s.Connect(context.Background(), incorrect)
+	a.So(err, should.NotBeNil)
 
-	a.So(s.Connect(&auth.Info{
+	_, err = s.Connect(context.Background(), &auth.Info{
 		Username: "no",
 		Password: []byte("test.app"),
-	}), should.NotBeNil)
+	})
+	a.So(err, should.NotBeNil)
 
-	a.So(s.Connect(&auth.Info{
+	_, err = s.Connect(context.Background(), &auth.Info{
 		Username: "no",
 		Password: []byte("test.gtw"),
-	}), should.NotBeNil)
+	})
+	a.So(err, should.NotBeNil)
 
 	app := &auth.Info{
 		Username: "test",
 		Password: []byte("test.app"),
 	}
-	a.So(s.Connect(app), should.BeNil)
+	_, err = s.Connect(context.Background(), app)
+	a.So(err, should.BeNil)
 
 	a.So(app.CanRead("test/devices/test/up"), should.BeTrue)
 	a.So(app.CanRead("other/devices/test/up"), should.BeFalse)
@@ -125,7 +132,8 @@ func TestTTNAuth(t *testing.T) {
 		Username: "test",
 		Password: []byte("test.gtw"),
 	}
-	a.So(s.Connect(gtw), should.BeNil)
+	_, err = s.Connect(context.Background(), gtw)
+	a.So(err, should.BeNil)
 
 	a.So(gtw.CanRead("connect"), should.BeFalse)
 	a.So(gtw.CanWrite("connect"), should.BeTrue)

--- a/pkg/session/connect.go
+++ b/pkg/session/connect.go
@@ -83,7 +83,7 @@ func (s *session) ReadConnect() error {
 	s.ctx = log.NewContext(s.ctx, logger)
 
 	if authInterface := auth.InterfaceFromContext(s.ctx); authInterface != nil {
-		if err = authInterface.Connect(s.auth); err != nil {
+		if ctx, err := authInterface.Connect(s.ctx, s.auth); err != nil {
 			if code, ok := err.(packet.ConnectReturnCode); ok {
 				connackPacket.ReturnCode = code
 				if err := s.conn.Send(connackPacket); err != nil {
@@ -92,6 +92,8 @@ func (s *session) ReadConnect() error {
 			}
 			logger.WithError(err).Debug("Rejected authentication")
 			return err
+		} else {
+			s.ctx = ctx
 		}
 	}
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, possibly referencing related issues:
Closes #0000, References #00000, etc.
-->

Allows implementers of `auth.Interface` to extend the session context. This comes in handy if information based on `auth.Info` needs to be available in the session context for later use.

<!--
If not related to an issue, please motivate why we need this pull request.
What is the current situation? What does this pull request improve?
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Take and return session context in `Connect()`
- Adapt in `pkg/auth/ttnauth`
- Leave indentation size up to developer's default